### PR TITLE
#1 solved 이중우선순위큐

### DIFF
--- a/Programmers/이중우선순위큐/이중우선순위큐_이승헌.java
+++ b/Programmers/이중우선순위큐/이중우선순위큐_이승헌.java
@@ -1,0 +1,34 @@
+package 이중우선순위큐;
+
+import java.util.TreeSet;
+
+public class 이중우선순위큐_이승헌 {
+    public static void main(String[] args) {
+        solution(new String[]{"I 16", "I -5643", "D -1", "D 1", "D 1", "I 123", "D -1"});
+        solution(new String[]{"I -45", "I 653", "D 1", "I -642", "I 45", "I 97", "D 1", "D -1", "I 333"});
+    }
+
+    public static int[] solution(String[] operations) {
+        int[] answer = new int[2];
+
+        TreeSet<Integer> treeSet = new TreeSet<>();
+        for (String operation : operations) {
+            String[] s = operation.split(" ");
+            if (s[0].equals("I")) { // Insert
+                treeSet.add(Integer.parseInt(s[1]));
+            } else if (s[0].equals("D")) { // Delete
+                if (s[1].equals("-1")) { // Min
+                    treeSet.pollFirst();
+                }else{ // Max
+                    treeSet.pollLast();
+                }
+            }
+        }
+
+        if(!treeSet.isEmpty()){
+            answer[0] = treeSet.last();
+            answer[1] = treeSet.first();
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
## 풀이 후기
문제 제목에서 대놓고 우선순위큐를 두개 쓰라고 하지만, 
TreeSet으로 문제를 푼 기억이 별로 없어서 TreeSet으로 시도해 보았습니다.

TreeSet은 내부적으로 Red-Black Tree를 사용하여 요소를 저장하고 관리하며, 시간복잡도는 다음과 같습니다.

삽입 (add): O(log n)
삭제 (remove): O(log n)
검색 (contains): O(log n)
최솟값 접근 (first): O(log n)
최댓값 접근 (last): O(log n)

PriorityQueue의 경우의 시간 복잡도는 다음과 같습니다.

삽입 (add): O(log n)
삭제 (remove, poll): O(log n)
검색 (contains): O(n)
최솟값 접근 (peek): O(1)

따라서, 문제에서 요구하는 삽입 삭제에 대해 시간적인 차이가 나지 않는다고 판단하였고, TreeSet 하나만 이용하여 문제를 해결하였습니다.


## 문제 풀이 핵심 키워드
- TreeSet

## 리뷰로 궁금한 점

## 확인 사항
- [x] Branch Convention : <날짜(YYMMDD)>_<본인이름>
- [x] Comment Message Convention : #<문제이슈번호> <풀이여부> <문제명>
- [x] Folder Convention : /<사이트명>/<문제이름>/<파일명>
- [x] Filer Convention : <문제명>_<본인이름>.<확장자>
- [x] 챌린지 운영진의 코드리뷰를 원하는 경우, `리뷰로 궁금한 점`에 `@eona1301`을 태그하세요.