### PR TITLE
#199 부분합

### DIFF
--- a/Baekjoon/부분합/부분합_김종현.java
+++ b/Baekjoon/부분합/부분합_김종현.java
@@ -1,0 +1,29 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int S = Integer.parseInt(st.nextToken());
+        int[] arr = new int[N + 1];
+
+        st = new StringTokenizer(br.readLine());
+        for(int i=1; i<=N; i++) {
+            arr[i] = arr[i-1] + Integer.parseInt(st.nextToken());
+        }
+
+
+        int MAX = (int) 2e6+1;
+        int K = MAX;
+        int L = 0;
+        int R = 1;
+        while(L<R && R<=N) {
+            if(arr[R]-arr[L]>=S) K = Math.min(K,R-L++);
+            else R++;
+        }
+        System.out.println(K==MAX ? 0 : K);
+    }
+}


### PR DESCRIPTION
#199 

## 풀이 후기
어려웠습니다.

## 문제 풀이 핵심 키워드
-  투포인터 응용 문제. 맨앞에서 시작하는 L,R 두 좌표를 기반으로, `L~R` 사이의 수열의 합이 `S` 보다 이상인지 확인한다.
-  `S` 보다 이상인 경우의 수열의 길이 가운데 최소의 길이를 찾으면 된다.
-  매 탐색마다 매번 길이의 합을 구하기 보다는 탐색이 시작 되기전 누적합을 진행하여 수열 간 덧셈 연산을 회피할 수 있다.

## 리뷰로 궁금한 점
(확인받고 싶은 기준을 작성해주시면 좋습니다.)

## 확인 사항
- [X] Branch Convention : <날짜(YYMMDD)>_<본인이름>
- [X] Comment Message Convention : #<문제이슈번호> <풀이여부> <문제명>
- [X] Folder Convention : /<사이트명>/<문제이름>/<파일명>
- [X] Filer Convention : <문제명>_<본인이름>.<확장자>
- [X] 챌린지 운영진의 코드리뷰를 원하는 경우, `리뷰로 궁금한 점`에 `@eona1301`을 태그하세요.