### PR TITLE
#199 부분합

### DIFF
--- a/Baekjoon/부분합/부분합_손효민.java
+++ b/Baekjoon/부분합/부분합_손효민.java
@@ -1,0 +1,42 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+
+	static int N, start, end, sum;
+	static long S, ans;
+	static int[] arr;
+	
+	public static void main(String[] args) throws Exception{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		S = Long.parseLong(st.nextToken());
+		arr = new int[N];
+		
+		st = new StringTokenizer(br.readLine());
+		for(int i = 0; i < N; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		
+		ans = 100000000;
+		start = 0;
+		end = 0;
+		sum = 0;
+		
+		while(true) {
+			if(sum >= S) {
+				sum -= arr[start++];
+				
+				int res = end - start +1;
+				ans = Math.min(ans, res);
+			}
+			else if(end == N) break;
+			else if(sum < S) {
+				sum += arr[end++];
+			}
+		}
+		if(ans == 100000000) System.out.println(0);
+		else	System.out.println(ans);	
+	}
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX1opVJj0bKKYea3QZQR7HrzZ6EEdhTF4%2Fcollaboration.svg%3FcacheSeconds%3D60)](https://workerb.linearb.io/v2/badge/collaboration-page?magicLinkId=Q5TGRUs)
## 풀이 후기
평이했습니다.

## 문제 풀이 핵심 키워드
- 투포인터 알고리즘을 사용해서 배열에서 합이 S 이상인 가장 짧은 연속적인 부분 배열의 길이를 찾도록 구현해봤습니다.
- 문제에서 0 < S ≤ 100,000,000이었기 때문에 sum 값을 long 타입으로 해야합니다.

## 리뷰로 궁금한 점
메모리 크기가 많이 나왔는데, 줄이는 방법이 있었을 지 궁금합니다.

## 확인 사항
- [x] Branch Convention : <날짜(YYMMDD)>_<본인이름>
- [x] Comment Message Convention : #<문제이슈번호> <풀이여부> <문제명>
- [x] Folder Convention : /<사이트명>/<문제이름>/<파일명>
- [x] Filer Convention : <문제명>_<본인이름>.<확장자>
- [x] 챌린지 운영진의 코드리뷰를 원하는 경우, `리뷰로 궁금한 점`에 `@eona1301`을 태그하세요.