### PR TITLE
#196 광물캐기

### DIFF
--- a/Programmers/광물캐기/광물캐기_조은영.cpp
+++ b/Programmers/광물캐기/광물캐기_조은영.cpp
@@ -1,0 +1,68 @@
+#include <string>
+#include <vector>
+#include <algorithm>
+
+using namespace std;
+
+int getScore(string mineral) {
+    if (mineral == "diamond") return 25;
+    else if (mineral == "iron") return 5;
+    else return 1;
+}
+
+int solution(vector<int> picks, vector<string> minerals) {
+    int answer = 0;
+    int pickCnt = 0;
+    int mineralSize = minerals.size();
+
+    vector<pair<int, int>>group;
+
+    for (int pick : picks) pickCnt += pick;
+
+    int maxMineralSize = pickCnt * 5;
+
+    if (maxMineralSize < mineralSize) {
+        minerals.erase(minerals.begin() + maxMineralSize, minerals.end());
+        mineralSize = minerals.size();
+    }
+
+    // ±¤¼® ¹è¿­ 5°³¾¿ Àß¶ó¼­ ¾î¶² ±¤¼®ÀÌ ¸¹ÀºÁö ÆÄ¾Ç
+    for (int i = 0; i < mineralSize; i += 5) {
+        int score = 0;
+        for (int j = i; j < min(mineralSize, i + 5); j++) {
+            score += getScore(minerals[j]);
+        }
+        group.push_back({ score, i });
+    }
+
+    sort(group.rbegin(), group.rend());
+
+    // °î±ªÀÌ ¹èÁ¤
+    for (int i = 0; i < group.size(); i++) {
+        int startIdx = group[i].second;
+        if (picks[0] > 0) {
+            for (int j = startIdx; j < min(mineralSize, startIdx + 5); j++) {
+                answer += 1;
+            }
+            picks[0]--;
+        }
+        else if (picks[1] > 0) {
+            for (int j = startIdx; j < min(mineralSize, startIdx + 5); j++) {
+                if (minerals[j] == "diamond") answer += 5;
+                else answer += 1;
+            }
+            picks[1]--;
+        }
+        else if (picks[2] > 0) {
+            for (int j = startIdx; j < min(mineralSize, startIdx + 5); j++) {
+                if (minerals[j] == "diamond") answer += 25;
+                else if (minerals[j] == "iron") answer += 5;
+                else answer += 1;
+            }
+            picks[2]--;
+        }
+        else break;
+    }
+
+    return answer;
+}

--- a/Programmers/수식최대화/수식최대화_조은영.cpp
+++ b/Programmers/수식최대화/수식최대화_조은영.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <cstdlib>
+
+using namespace std;
+
+long long applyOperation(long long a, long long b, char op) {
+    if (op == '+') return a + b;
+    if (op == '-') return a - b;
+    if (op == '*') return a * b;
+    return 0;
+}
+
+long long evaluate(vector<long long> numbers, vector<char> ops, vector<char> precedence) {
+    vector<long long> tmpNums = numbers;
+    vector<char> tmpOps = ops;
+
+
+    for (char op : precedence) {
+        for (int i = 0; i < tmpOps.size(); ) {
+            if (tmpOps[i] == op) {
+                long long result = applyOperation(tmpNums[i], tmpNums[i + 1], op);
+                tmpNums[i] = result;
+                tmpNums.erase(tmpNums.begin() + i + 1);
+                tmpOps.erase(tmpOps.begin() + i);
+            }
+            else {
+                i++;
+            }
+        }
+    }
+    return tmpNums[0];
+}
+
+long long solution(string expression) {
+    vector<long long> numbers;
+    vector<char> operators;
+    vector<char> uniqueOps;
+
+    string num = "";
+    for (char c : expression) {
+        if (isdigit(c)) {
+            num += c;
+        }
+        else {
+            numbers.push_back(stoll(num));
+            num = "";
+            operators.push_back(c);
+            if (find(uniqueOps.begin(), uniqueOps.end(), c) == uniqueOps.end()) {
+                uniqueOps.push_back(c);
+            }
+        }
+    }
+    numbers.push_back(stoll(num));
+
+    sort(uniqueOps.begin(), uniqueOps.end());
+    long long maxResult = 0;
+    do {
+        long long result = evaluate(numbers, operators, uniqueOps);
+        maxResult = max(maxResult, abs(result));
+    } while (next_permutation(uniqueOps.begin(), uniqueOps.end()));
+
+    return maxResult;
+}
+


### PR DESCRIPTION
## 풀이 후기
평이했습니다.

## 문제 풀이 핵심 키워드
- minerals 배열을 5개 단위로 끊고 광물별 가중치를 줘서 그룹별 가중치 합을 구합니다. (getScore 함수)
  그리고 그룹별 가중치 합과 함께 시작 인덱스(5개 단위 그룹의 시작인덱스)를 group에 저장합니다.
  가중치 합을 기준으로 내림차순 정렬합니다. 이렇게 하면 캐기 어려운 광물이 많은 그룹일수록 앞으로 오게 됩니다.
  이제 그룹을 탐색하며 그룹의 시작 인덱스를 기준으로 minerals 배열에서 5개 단위로 피로도를 계산하면 됩니다. 캐기 어려운 광물이 많은 그룹이 앞으로 왔으므로 좋은 곡괭이부터 쓰면 최소한의 피로도가 보장됩니다.
- 광물 개수가 5배수라는 보장이 없으니 반복문을 돌 때 주의해야합니다. 저는 min 함수로 처리했습니다.
- 곡괭이로 채굴 가능한 수가 광물의 수보다 작을 때를 생각해야합니다. 이 경우엔 남는 광물들은 어차피 못캐니까요. 이 조건을 생각하지 않아서 처음에 틀렸었네요... 만약 곡괭이로 채굴 가능한 수 < 광물의 수라면 범위가 같아지게 광물 배열을 잘라주는 조건문을 넣어서 해결했습니다.

## 리뷰로 궁금한 점
(확인받고 싶은 기준을 작성해주시면 좋습니다.)

## 확인 사항
- [x] Branch Convention : <날짜(YYMMDD)>_<본인이름>
- [x] Comment Message Convention : #<문제이슈번호> <풀이여부> <문제명>
- [x] Folder Convention : /<사이트명>/<문제이름>/<파일명>
- [x] Filer Convention : <문제명>_<본인이름>.<확장자>
- [x] 챌린지 운영진의 코드리뷰를 원하는 경우, `리뷰로 궁금한 점`에 `@eona1301`을 태그하세요.