### PR TITLE
#351 solved 문자열교환 76ms 11.5mb

### DIFF
--- a/Backjoon/N번째큰수/N번째큰수_이승헌.java
+++ b/Backjoon/N번째큰수/N번째큰수_이승헌.java
@@ -1,0 +1,26 @@
+package N번째큰수;
+
+import java.util.*;
+import java.io.*;
+
+public class N번째큰수_이승헌 {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n*n];
+        int idx =0;
+
+        for(int i=0; i<n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<n; j++) {
+                arr[idx++] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        Arrays.sort(arr);
+
+        System.out.println(arr[n*n - n]);
+    }
+}

--- a/Backjoon/문자열교환/문자열교환_이승헌.java
+++ b/Backjoon/문자열교환/문자열교환_이승헌.java
@@ -1,0 +1,45 @@
+package 문자열교환;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class 문자열교환_이승헌 {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String str = br.readLine();
+
+        int len = str.length();
+        boolean[] dp = new boolean[2 * len];
+        int aCnt = 0;
+        for (int idx = 0; idx < len; idx++) {
+            if (str.charAt(idx) == 'a') {
+                aCnt++;
+                dp[idx] = true;
+            }
+        }
+        System.arraycopy(dp, 0, dp, len, len);
+
+        int min = 0;
+        for (int i = 0; i < aCnt; i++) {
+            if (str.charAt(i) == 'b') {
+                min ++;
+            }
+        }
+
+        int start = min;
+        int maxLen = len + aCnt;
+        for (int i = aCnt; i < maxLen; i++) {
+            if(!dp[i]){
+                start ++;
+            }
+            if(!dp[i - aCnt]){
+                start --;
+                min = Math.min(min, start);
+            }
+        }
+
+        System.out.println(min);
+    }
+}


### PR DESCRIPTION
## 📝 풀이 후기

처음 풀이방식은 _idx를 len으로 모듈러 연산_ 하여 b의 갯수를 카운팅 해 주는 방법으로 진행했습니다.
이 결과 240ms 정도의 시간이 나왔고,

처음 b의 갯수를 세고 슬라이딩 윈도우를 사용한 결과 80ms 정도로 줄일 수 있었습니다.
여기서, _idx를 len으로 모듈러 연산_ 했던 방법을 len을 2배로 복사하는 방법으로 변경하여 문제를 해결하였는데,
이 부분에서는 크게 시간효율을 얻지는 못했네요.

char.At으로 일일이 탐색했을때보다, dp로 저장을 했을때 4ms 정도 줄일 수 있었습니다.



## 📚 문제 풀이 핵심 키워드
슬라이딩 윈도우


## 🤔 리뷰로 궁금한 점



## 🧑‍💻 제출자 확인 사항
- [x] Convention이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.