### PR TITLE
#466 지름길 68ms 11.7mb

### DIFF
--- a/Backjoon/N번째큰수/N번째큰수_이승헌.java
+++ b/Backjoon/N번째큰수/N번째큰수_이승헌.java
@@ -1,0 +1,26 @@
+package N번째큰수;
+
+import java.util.*;
+import java.io.*;
+
+public class N번째큰수_이승헌 {
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+        int[] arr = new int[n*n];
+        int idx =0;
+
+        for(int i=0; i<n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<n; j++) {
+                arr[idx++] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        Arrays.sort(arr);
+
+        System.out.println(arr[n*n - n]);
+    }
+}

--- a/Backjoon/지름길/지름길_이승헌.java
+++ b/Backjoon/지름길/지름길_이승헌.java
@@ -8,13 +8,14 @@ import java.util.PriorityQueue;
 import java.util.StringTokenizer;
 
 public class 지름길_이승헌 {
+    static PriorityQueue<Node> fast = new PriorityQueue<>();
+    static int M;
+
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
         StringTokenizer st = new StringTokenizer(br.readLine());
         int N = Integer.parseInt(st.nextToken());
-        int M = Integer.parseInt(st.nextToken());
-
-        PriorityQueue<Node> fast = new PriorityQueue<>();
+        M = Integer.parseInt(st.nextToken());
 
         for (int idx = 0; idx < N; idx++) {
             st = new StringTokenizer(br.readLine());
@@ -26,17 +27,17 @@ public class 지름길_이승헌 {
             }
             fast.add(new Node(start, end, dis));
         }
-
-        System.out.println(solve(fast, M));
+        System.out.println(solve());
     }
 
-    private static int solve(PriorityQueue<Node> fast, int M) {
+    private static int solve() {
 
         PriorityQueue<Node> pq = new PriorityQueue<>();
         pq.offer(new Node(0, 0, 0));
         int[] dp = new int[M + 1];
         Arrays.fill(dp, Integer.MAX_VALUE);
         int nextDis;
+        Node firstLoad;
 
         while (!pq.isEmpty()) {
             Node cur = pq.poll();
@@ -47,8 +48,13 @@ public class 지름길_이승헌 {
             while (!fast.isEmpty() && fast.peek().start < cur.start) {
                 fast.poll();
             }
+            firstLoad = fast.peek();
 
             for (Node nextLoad : fast) {
+                if (nextLoad.start > firstLoad.end) {
+                    continue;
+                }
+
                 nextDis = cur.distance + nextLoad.distance + (nextLoad.start - cur.start);
                 if (cur.start > nextLoad.start || dp[nextLoad.end] < nextDis) {
                     continue;

--- a/Backjoon/지름길/지름길_이승헌.java
+++ b/Backjoon/지름길/지름길_이승헌.java
@@ -1,0 +1,89 @@
+package 지름길;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class 지름길_이승헌 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        PriorityQueue<Node> fast = new PriorityQueue<>();
+
+        for (int idx = 0; idx < N; idx++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            int dis = Integer.parseInt(st.nextToken());
+            if (end > M || end - start < dis) {
+                continue;
+            }
+            fast.add(new Node(start, end, dis));
+        }
+
+        System.out.println(solve(fast, M));
+    }
+
+    private static int solve(PriorityQueue<Node> fast, int M) {
+
+        PriorityQueue<Node> pq = new PriorityQueue<>();
+        pq.offer(new Node(0, 0, 0));
+        int[] dp = new int[M + 1];
+        Arrays.fill(dp, Integer.MAX_VALUE);
+        int nextDis;
+
+        while (!pq.isEmpty()) {
+            Node cur = pq.poll();
+            if (cur.start == M) {
+                return cur.distance;
+            }
+
+            while (!fast.isEmpty() && fast.peek().start < cur.start) {
+                fast.poll();
+            }
+
+            for (Node nextLoad : fast) {
+                nextDis = cur.distance + nextLoad.distance + (nextLoad.start - cur.start);
+                if (cur.start > nextLoad.start || dp[nextLoad.end] < nextDis) {
+                    continue;
+                }
+                dp[nextLoad.end] = nextDis;
+                pq.offer(new Node(nextLoad.end, 0, nextDis));// 다음 지름길까지 더함
+            }
+
+            if (dp[M] > cur.distance + M - cur.start) {
+                dp[M] = cur.distance + M - cur.start;
+                pq.offer(new Node(M, 0, dp[M]));
+            }
+        }
+
+        return M;
+    }
+
+    private static class Node implements Comparable<Node> {
+        int start;
+        int end;
+        int distance;
+
+        public Node(int start, int end, int distance) {
+            this.start = start;
+            this.end = end;
+            this.distance = distance;
+        }
+
+        @Override
+        public int compareTo(Node o) {
+            if (start == o.start) {
+                return distance - o.distance;
+            }
+            return start - o.start;
+        }
+    }
+}
+


### PR DESCRIPTION
## 📝 풀이 후기
1. 지름길 역할을 못하는 길은 저장하지 않았습니다.
2. 이미 지난 지름길은 탐색에서 제외했습니다.
3. 첫 지름길을 미리 저장하여, 해당 지름길을 무조건 건너야하는 경우 전체 거리가 줄어들기에 반복분을 통과하게 했습니다.


## 📚 문제 풀이 핵심 키워드
- 다익스트라

## 🤔 리뷰로 궁금한 점

```java
while (!fast.isEmpty() && fast.peek().start < cur.start) {
      fast.poll();
  }
```
에서 pq의 이미 지난 지름길을 제거해 주고 있습니다.

그 후, **지름길을 순회하면서 `cur.start > nextLoad.start ` 에 걸린다면 `continue;`해주고 있는데,
사실상 이 조건은 필요 없는 조건이라 생각합니다.**

하지만 이 조건이 있는냐 없느냐에 따라 4ms 정도 차이가 나는데 정확한 이유를 모르겠습니다.
(오히려 있는게 4ms 정도 빠르게 나타납니다.)

@hadevyi 이 부분에 관해서 혹시 이유를 알고 계시면 답글 부탁드려요 ! 항상 고생 많으십니다 !! 🙂

## 🧑‍💻 제출자 확인 사항
- [x] Convention이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
4. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.