### PR TITLE
#793 도넛과 막대 그래프

### DIFF
--- a/Programmers/도넛과막대그래프/도넛과막대그래프_김종현.java
+++ b/Programmers/도넛과막대그래프/도넛과막대그래프_김종현.java
@@ -1,0 +1,82 @@
+// 연결하는 정점
+// - out만 가짐. 단, 여러 그래프를 가지므로 보통 out은 2이상
+
+// 도넛 그래프
+// - 사이클 있음
+// - 각 노드별 in, out 1개씩
+// - 막대, 8자를 제외한 나머지
+
+// 막대 그래프
+// - 사이클 없음
+// - in, out 중 1개만 가진 경우가 있음.
+// - in, out이 아예 없는 경우도 막대로 본다. (1개짜리 막대그래프)
+
+// 8자 그래프
+// - 2n+1의 노드 갯수, 2n+2의 간선
+// - 사이클 있음
+// - in, out이 2개인 경우가 있음.
+
+import java.util.*;
+class Solution {
+    private static List<Integer> list[];
+    private static boolean[] visited;
+    public int[] solution(int[][] edges) {                
+        int len = (int)1e6+4;
+        
+        int[] in = new int[len];
+        int[] out = new int[len];
+        
+        int max = 0;
+        
+        // 각 생성된 노드 번호가 순차적임을 보장하지 않았다.
+        // 즉, 식별은 가능하나 랜덤한 값이 제공될 수도 있다.
+        // 따라서 set을 이용한다.
+        Set<Integer> s = new HashSet<>(); 
+        
+        // in, out 계산
+        for(int[] edge : edges) {
+            out[edge[0]]++;
+            in[edge[1]]++;
+            max = Math.max(max, Math.max(edge[0], edge[1]));
+            s.add(edge[0]);
+            s.add(edge[1]);
+        }
+    
+        int root = 0; // 정점
+        for(int num : s) {
+            if(in[num] == 0 && out[num] >=2) {
+                root = num;
+                break;
+            }
+        }
+          
+        int total = 0; // 총 그래프 갯수
+        for(int[] edge : edges) {
+            int n1 = edge[0];
+            int n2 = edge[1];
+
+            if(n1 != root) continue;
+            
+            out[n1]--;
+            in[n2]--;
+            total++;
+        }
+        
+        int g2 = 0; // 막대
+        int g3 = 0; // 8자
+        
+        for(int i=1; i<=max; i++) {
+            if(!s.contains(i) || i==root) continue;
+            
+            if(in[i]==2 && out[i]==2) {
+                g3++;
+            } else if(out[i]==0)  {
+                if(in[i]==0 || in[i]==1) {
+                    g2++;
+                }
+            }
+        }
+        
+        return new int[] {root, total-g2-g3, g2, g3};
+    }
+}


### PR DESCRIPTION
#793 

## 📝 풀이 후기
어려웠습니다.

## 📚 문제 풀이 핵심 키워드
1. 그래프 및 진출/진입 차수 응용 문제. 도넛, 막대, 8자가 가지는 그래프의 차이를 파악하는 문제이다.
2. 이 문제의 경우, 그래프 탐색을 통해 풀어도 시간초과가 나지 않지만 그래프의 차이를 명확히 이해하면 그래프를 형성하지 않아도 문제를 풀 수 있다. 각 그래프의 차이는 다음과 같다.
    - 8자 : 해당 그래프에는 각 노드 가운데 `in, out`  이 둘다 2인 노드가 1개 존재한다.
    - 막대 : 해당 그래프에는 각 노드 가운데 `in`이 1개이고 `out`이 없는 노드가 1개 존재한다. (단, 막대 그래프 사이즈가 1개인 경우에는 `in,out`이 둘다 없으므로 이를 유의하자.)
    - 도넛 : 해당 그래프는 모든 노드가 `in,out` 을 각각 1개씩 가진다. 이 경우는 일일이 그래프 탐색을 하지 않는 이상 파악하기 어렵다. 따라서 총 그래프 갯수에서, 8자와 막대 그래프의 합을 빼는 것으로 그래프 갯수를 파악하는 방법을 적용했다.
    - 정점 : 각 그래프를 연결하는 노드이므로, `out`만 있는 노드이다. 그래프는 2개 이상 연결되어 있으므로, `in=0, out>=2` 이상인 노드가 정점 노드가 된다.

## 🤔 리뷰로 궁금한 점
<!-- 확인받고 싶은 기준을 작성해주시면 좋습니다. -->

## 🧑‍💻 제출자 확인 사항
- [x] Convention이 올바른가요?
- [x] 괄호 내 안내문은 삭제하셨나요?
- [x] 본인의 체감 난도 Label을 등록했나요?
- [x] 제출자 확인 사항을 모두 확인하셨나요?

## 🕵️ 리뷰어 확인 사항
1. 컨벤션이 올바르지 않다면, Request Changes 해주세요.
2. 제출자의 풀이코드의 좋은 점 혹은 개선사항을 남기고 Approve 해주세요.